### PR TITLE
Add files to pack into a dotnet templates

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "SoftwareAteliers",
+  "classifications": ["Web", "SPA", "Vue.js"],
+  "identity": "SoftwareAteliers.AspNetCoreVueStarter",
+  "name": ".NET Core Vue.js",
+  "shortName": "vue",
+  "sourceName": "AspNetCoreVueStarter",
+  "preferNameDirectory": false,
+  "primaryOutputs": [{ "path": "AspNetCoreVueStarter.csproj" }],
+  "sources": [
+    {
+      "source": "./",
+      "target": "./",
+      "exclude": [".template.config/**"]
+    }
+  ],
+  "symbols": {
+    "skipBuild": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic build of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "postActions": [
+    {
+      "condition": "(!skipBuild)",
+      "description": "Restore, then build this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet build'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/SoftwareAteliers.AspNetCoreVueStarter.nuspec
+++ b/SoftwareAteliers.AspNetCoreVueStarter.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>SoftwareAteliers.AspNetCoreVueStarter</id>
+    <version>1.0.0</version>
+    <description>
+      ASP.NET Core + Vue.js starter project
+    </description>
+    <authors>SoftwareAteliers</authors>
+    <projectUrl>https://github.com/SoftwareAteliers/asp-net-core-vue-starter</projectUrl>
+    <licenseUrl>https://github.com/SoftwareAteliers/asp-net-core-vue-starter/blob/master/content/LICENSE</licenseUrl>
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file
+      src="**"
+      exclude="**/node_modules/**;**/bin/**;**/obj/**;**/.vs/**;**/.vscode/**;**/ClientApp/dist/**;**/wwwroot/dist/**;content/Directory.Build.*;**/.git/**"
+      target="Content" />
+  </files>
+</package>


### PR DESCRIPTION
In reference to issue #4 

Adds:
* .template folder to specify scaffolding behaviour
  * Namespace is automatically taken from folder name
  * Build can be skipped after generation with _--skipRestore_ option
* Nuspec file to generate the Nuget package

Tested as follow:
1. Generate the Nuget package with `nuget pack .\SoftwareAteliers.AspNetCoreVueStarter.nuspec -OutputDirectory C:/LocalNugetFeed` (where LocalNugetFeed is a local Nuget repository)
2. Install the package with `dotnet new -i SoftwareAteliers.AspNetCoreVueStarter`
3. Scaffold a test project with `dotnet new vue -o MyProject`

Let me know if you have any improvement or correction to naming I used.