### PR TITLE
Enabling HTTPS by default for development

### DIFF
--- a/AspNetCoreVueStarter.csproj
+++ b/AspNetCoreVueStarter.csproj
@@ -13,14 +13,14 @@
     <Copyright>MIT 2020 Software Ateliers</Copyright>
     <AssemblyName>AspNetCoreVueStarter</AssemblyName>
     <RootNamespace>AspNetCoreVueStarter</RootNamespace>
-	<Version>2.5.1</Version>
-	<AssemblyVersion>2.5.1.0</AssemblyVersion>
-	<FileVersion>2.5.1.0</FileVersion>
+    <Version>2.5.1</Version>
+    <AssemblyVersion>2.5.1.0</AssemblyVersion>
+    <FileVersion>2.5.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.8" />
-    <PackageReference Include="VueCliMiddleware" Version="3.1.1" />
+    <PackageReference Include="VueCliMiddleware" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Startup.cs
+++ b/Startup.cs
@@ -44,9 +44,10 @@ namespace AspNetCoreVueStarter
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-                app.UseHttpsRedirection();
             }
 
+            app.UseHttpsRedirection();
+            
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 


### PR DESCRIPTION
We recently merged a PR in https://github.com/EEParker/aspnetcore-vueclimiddleware to allow for way easier HTTPS handling, basically out of the box. This PR bumps that package to use it for the template. 